### PR TITLE
Use new constructor in USE_SIMPLE_CTOR_DTOR (#17080)

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -945,8 +945,8 @@ class Operator : public OperatorBase {
 #define USE_OPERATOR_CONTEXT_FUNCTIONS USE_OPERATOR_FUNCTIONS(Context)
 
 #define USE_SIMPLE_CTOR_DTOR(name)                                             \
-  name(const OperatorDef& operator_def, Workspace* ws)                         \
-      : Operator<Context>(operator_def, ws) {}                                 \
+  template<class... Args> explicit name(Args&&... args)                        \
+      : Operator<Context>(std::forward<Args>(args)...) {}                      \
   virtual ~name() noexcept {}
 
 // Helpers to implement runtime op polymorphism. Often it's convenient to make


### PR DESCRIPTION
Stack:
* (to be filled)

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/17080

This changes all operators using this macro to the new format

Reviewed By: dzhulgakov

Differential Revision: D14078628

fbshipit-source-id: 67048e485e326765fd49567cc008633d3d500d5c