### PR TITLE
Fix some documentation links in torch.tensor (#17109)

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -256,11 +256,11 @@ class Tensor(torch._C._TensorBase):
         return torch.argmin(self, dim, keepdim)
 
     def argsort(self, dim=None, descending=False):
-        r"""See :func: `torch.argsort`"""
+        r"""See :func:`torch.argsort`"""
         return torch.argsort(self, dim, descending)
 
     def norm(self, p="fro", dim=None, keepdim=False, dtype=None):
-        r"""See :func: `torch.norm`"""
+        r"""See :func:`torch.norm`"""
         return torch.norm(self, p, dim, keepdim, dtype=dtype)
 
     def potrf(self, upper=True):


### PR DESCRIPTION
Stack:
* (to be filled)

Summary:
Currently it's broken https://pytorch.org/docs/stable/tensors.html#torch.Tensor.norm
Pull Request resolved: https://github.com/pytorch/pytorch/pull/17109

Differential Revision: D14093567

Pulled By: ezyang

fbshipit-source-id: b167cde2150ee97ccf5689fcf50ff8157acfce10